### PR TITLE
[@svelteui/actions] fix duplicate event listeners on destroy in use-hot-key.ts

### DIFF
--- a/packages/svelteui-composables/src/lib/actions/use-hot-key/use-hot-key.ts
+++ b/packages/svelteui-composables/src/lib/actions/use-hot-key/use-hot-key.ts
@@ -44,7 +44,7 @@ export function hotkey(node: HTMLElement, hotkeys: HotkeyItem[]): ReturnType<Act
 			hotkeys = updatedHotKeys;
 		},
 		destroy: () => {
-			document.documentElement.addEventListener('keydown', keyDownListener);
+			document.documentElement.removeEventListener('keydown', keyDownListener);
 		}
 	};
 }


### PR DESCRIPTION
Fixes https://github.com/svelteuidev/svelteui/issues/143